### PR TITLE
renovate: defer huggingface_hub & block Python 3.13 bumps in GHA

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,18 @@
             "matchPackageNames": ["torch"],
             "allowedVersions": "<3.0.0",
             "rangeStrategy": "widen"
+        },
+        {
+            "matchPackageNames": ["huggingface_hub"],
+            "matchUpdateTypes": ["minor", "major"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["github-actions"],
+            "matchDepNames": ["python"],
+            "matchDatasources": ["python-version"],
+            "allowedVersions": "<3.13",
+            "rangeStrategy": "replace"
         }
     ]
 }


### PR DESCRIPTION
This PR updates renovate.json:\n- Defer minor/major updates for huggingface_hub (reduce breakage risk)\n- Block GitHub Actions python-version bumps to >=3.13 (stay on <3.13)\n\nRationale:\n- huggingface_hub minor/major regularly brings API changes and pinned transitive deps; we’ll opt-in later.\n- Our current Torch/basicsr caps target Python <=3.12; 3.13 updates break CI (see PR #23).\n\nOnce we’re ready, we can remove these rules or set narrower allowedVersions.